### PR TITLE
get_next_sample in hyperband modification

### DIFF
--- a/hpopt/hyperband.py
+++ b/hpopt/hyperband.py
@@ -376,7 +376,7 @@ class AsyncHyperBand(HpOpt):
             )
 
             if (
-                imgs_for_full_train != -1 # finished trial  finish.
+                imgs_for_full_train != -1 # finished trial finish.
                 and (self._expected_total_images * 1.2
                      < num_trained_images + imgs_for_full_train)
             ):

--- a/hpopt/hyperband.py
+++ b/hpopt/hyperband.py
@@ -366,11 +366,20 @@ class AsyncHyperBand(HpOpt):
         # Check total number of trained images
         if self._expected_total_images > 0:
             num_trained_images = self.get_num_trained_images()
+            _, imgs_for_full_train = hpopt.get_best_score_with_num_imgs(
+                self.save_path, trial_id, self.mode)
+
             logger.debug(
                 f"expected total images = {self._expected_total_images} "
                 f"num_images = {num_trained_images}"
+                f"imgs_for_full_train = {imgs_for_full_train}"
             )
-            if num_trained_images >= self._expected_total_images:
+
+            if (
+                imgs_for_full_train != -1 # finished trial  finish.
+                and (self._expected_total_images * 1.2
+                     < num_trained_images + imgs_for_full_train)
+            ):
                 return None
 
         # Choose a config


### PR DESCRIPTION
This PR includes modification to get_next_sample in hyperband.
Current code starts a new trial if number of expected images are bigger than trained images at that time.
But if two things are almost same. It actually uses (expected time ratio + 1) times finetune train time.
This PR makes get_next_sample start a new trial only if the addition of reft of imgs and trained imgs is less than 120% expected time ratio.