### PR TITLE
Es/hyper band get next sample modification

### DIFF
--- a/hpopt/hyperband.py
+++ b/hpopt/hyperband.py
@@ -376,7 +376,7 @@ class AsyncHyperBand(HpOpt):
             )
 
             if (
-                imgs_for_full_train != -1 # finished trial  finish.
+                imgs_for_full_train != -1 # finished trial finish.
                 and (self._expected_total_images * 1.2
                      < num_trained_images + imgs_for_full_train)
             ):

--- a/hpopt/hyperband.py
+++ b/hpopt/hyperband.py
@@ -366,11 +366,20 @@ class AsyncHyperBand(HpOpt):
         # Check total number of trained images
         if self._expected_total_images > 0:
             num_trained_images = self.get_num_trained_images()
+            _, imgs_for_full_train = hpopt.get_best_score_with_num_imgs(
+                self.save_path, trial_id, self.mode)
+
             logger.debug(
                 f"expected total images = {self._expected_total_images} "
                 f"num_images = {num_trained_images}"
+                f"imgs_for_full_train = {imgs_for_full_train}"
             )
-            if num_trained_images >= self._expected_total_images:
+
+            if (
+                imgs_for_full_train != -1 # finished trial  finish.
+                and (self._expected_total_images * 1.2
+                     < num_trained_images + imgs_for_full_train)
+            ):
                 return None
 
         # Choose a config

--- a/hpopt/hyperband.py
+++ b/hpopt/hyperband.py
@@ -366,19 +366,15 @@ class AsyncHyperBand(HpOpt):
         # Check total number of trained images
         if self._expected_total_images > 0:
             num_trained_images = self.get_num_trained_images()
-            _, imgs_for_full_train = hpopt.get_best_score_with_num_imgs(
-                self.save_path, trial_id, self.mode)
 
             logger.debug(
                 f"expected total images = {self._expected_total_images} "
-                f"num_images = {num_trained_images}"
-                f"imgs_for_full_train = {imgs_for_full_train}"
+                f"num_trained_image = {num_trained_images}"
+                f"number of image best trial used to trian = {self._current_best['image']}"
             )
 
-            if (
-                imgs_for_full_train != -1 # finished trial finish.
-                and (self._expected_total_images * 1.2
-                     < num_trained_images + imgs_for_full_train)
+            if (self._expected_total_images * 1.2
+                < num_trained_images + self._current_best['image']
             ):
                 return None
 


### PR DESCRIPTION
This PR modifies get_next_sample function in hyperband.
Current code makes a new trial if number of expected images are bigger than number of trained images at that time.
But if number of trained images is almost same with number of expected images,
It actually uses (expected time ratio + 1) times finetune train time.
This PR makes get_next_sample start a new trial,
only if the addition of number of left images and trained images is less than 120% expected time ratio.